### PR TITLE
Fix: Update validate.py and score.py to Improve Functionality and Align with Current Challenge Requirements

### DIFF
--- a/score.py
+++ b/score.py
@@ -36,6 +36,7 @@ def score(gold, gold_col, pred, pred_col):
         "Pearson_correlation": None if pd.isna(pearson) else pearson
     }
 
+
 def extract_gs_file(folder):
     """Extract goldstandard file from folder."""
     files = glob(os.path.join(folder, "*"))
@@ -49,6 +50,7 @@ def extract_gs_file(folder):
             f"Got {len(files)}. Exiting."
         )
     return files[0]
+
 
 def check_validation_status(filename, args):
     """

--- a/score.py
+++ b/score.py
@@ -67,7 +67,7 @@ def check_validation_status(filename, args):
                     "score_status":  "INVALID",
                     "score_errors": "Submission could not be evaluated due to validation errors."}
     
-        with open(args.output, "w") as out:
+        with open(filename, "w") as out:
             out.write(json.dumps(new_data))
 
         print("INVALID")

--- a/score.py
+++ b/score.py
@@ -7,8 +7,9 @@ Task 1 and 2 will return the same metrics:
 """
 
 import argparse
+from glob import glob
 import json
-
+import os
 import pandas as pd
 from sklearn.metrics import root_mean_squared_error
 from scipy.stats import pearsonr
@@ -35,28 +36,69 @@ def score(gold, gold_col, pred, pred_col):
         "Pearson_correlation": None if pd.isna(pearson) else pearson
     }
 
+def extract_gs_file(folder):
+    """Extract goldstandard file from folder."""
+    files = glob(os.path.join(folder, "*"))
+
+    # Filter out the manifest file
+    files = [f for f in files if os.path.basename(f) != 'SYNAPSE_METADATA_MANIFEST.tsv']
+
+    if len(files) != 1:
+        raise ValueError(
+            "Expected exactly one goldstandard file in folder. "
+            f"Got {len(files)}. Exiting."
+        )
+    return files[0]
+
+def check_validation_status(filename, args):
+    """
+    Determine whether the validate.py script successfully validated the data.
+    """
+    
+    with open(filename, "r") as f:
+        status_result = json.load(f)
+    print("Checking the validation_status.")
+    
+    if status_result.get("validation_status") == "INVALID":
+        new_data = {"validation_status": "INVALID",
+                    "validation_errors": status_result.get("validation_errors"),
+                    "score_status":  "INVALID",
+                    "score_errors": "Submission could not be evaluated due to validation errors."}
+    
+        with open(args.output, "w") as out:
+            out.write(json.dumps(new_data))
+
+        print(status_result.get("validation_status"))
+    else:
+        print("Scoring the submission.")
+        
+        pred = pd.read_csv(args.predictions_file)
+        gold = pd.read_csv(extract_gs_file(args.goldstandard_file))
+
+        # Replace spaces in column headers in case they're found.
+        gold.columns = [colname.replace(" ", "_") for colname in gold.columns]
+
+        # Strip leading and trailing spaces as needed.
+        gold = gold.map(lambda x: x.strip() if isinstance(x, str) else x)
+        pred = pred.map(lambda x: x.strip() if isinstance(x, str) else x)
+
+        scores = score(gold, "Experimental_Values",
+                        pred, "Predicted_Experimental_Values")
+        
+        with open(args.output, "w") as out:
+            res = {"validation_status": status_result.get("validation_status"),
+                    "validation_errors": status_result.get("validation_errors"),
+                    "score_status": "SCORED", "score_errors": "", **scores,
+                    }
+            out.write(json.dumps(res))
+        print("SCORED.")
+
 
 def main():
     """Main function."""
     args = get_args()
 
-    pred = pd.read_csv(args.predictions_file)
-    gold = pd.read_csv(args.goldstandard_file)
-
-    # Replace spaces in column headers in case they're found.
-    gold.columns = [colname.replace(" ", "_") for colname in gold.columns]
-
-    # Strip leading and trailing spaces as needed.
-    gold = gold.map(lambda x: x.strip() if isinstance(x, str) else x)
-    pred = pred.map(lambda x: x.strip() if isinstance(x, str) else x)
-
-    scores = score(gold, "Experimental_Values", 
-                   pred, "Predicted_Experimental_Values")
-
-    with open(args.output, "w") as out:
-        res = {"submission_status": "SCORED", **scores}
-        out.write(json.dumps(res))
-
+    check_validation_status(args.output, args)
 
 if __name__ == "__main__":
     main()

--- a/score.py
+++ b/score.py
@@ -19,7 +19,7 @@ def get_args():
     """Set up command-line interface and get arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
-    parser.add_argument("-g", "--goldstandard_file", type=str, required=True)
+    parser.add_argument("-g", "--goldstandard_folder", type=str, required=True)
     parser.add_argument("-o", "--output", type=str, default="results.json")
     return parser.parse_args()
 
@@ -75,7 +75,7 @@ def check_validation_status(filename, args):
         print("Scoring the submission.")
         
         pred = pd.read_csv(args.predictions_file)
-        gold = pd.read_csv(extract_gs_file(args.goldstandard_file))
+        gold = pd.read_csv(extract_gs_file(args.goldstandard_folder))
 
         # Replace spaces in column headers in case they're found.
         gold.columns = [colname.replace(" ", "_") for colname in gold.columns]

--- a/score.py
+++ b/score.py
@@ -91,7 +91,7 @@ def check_validation_status(filename, args):
                     "score_status": "SCORED", "score_errors": "", **scores,
                     }
             out.write(json.dumps(res))
-        print("SCORED.")
+        print("SCORED")
 
 
 def main():

--- a/score.py
+++ b/score.py
@@ -70,7 +70,7 @@ def check_validation_status(filename, args):
         with open(args.output, "w") as out:
             out.write(json.dumps(new_data))
 
-        print(status_result.get("validation_status"))
+        print("INVALID")
     else:
         print("Scoring the submission.")
         

--- a/validate.py
+++ b/validate.py
@@ -23,7 +23,7 @@ def get_args():
     """Set up command-line interface and get arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
-    parser.add_argument("-g", "--goldstandard_file", type=str, required=True)
+    parser.add_argument("-g", "--goldstandard_folder", type=str, required=True)
     parser.add_argument("-o", "--output", type=str, default="results.json")
     return parser.parse_args()
 
@@ -130,7 +130,7 @@ def main():
     args = get_args()
 
     invalid_reasons = validate(
-        gold_file=extract_gs_file(args.goldstandard_file), pred_file=args.predictions_file
+        gold_file=extract_gs_file(args.goldstandard_folder), pred_file=args.predictions_file
         )
 
     invalid_reasons = "\n".join(filter(None, invalid_reasons))

--- a/validate.py
+++ b/validate.py
@@ -27,6 +27,7 @@ def get_args():
     parser.add_argument("-o", "--output", type=str, default="results.json")
     return parser.parse_args()
 
+
 def extract_gs_file(folder):
     """Extract goldstandard file from folder."""
     files = glob(os.path.join(folder, "*"))
@@ -40,6 +41,7 @@ def extract_gs_file(folder):
             f"Got {len(files)}. Exiting."
         )
     return files[0]
+
 
 def check_dups(pred):
     """Check for duplicate mixtures."""

--- a/validate.py
+++ b/validate.py
@@ -24,8 +24,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
     parser.add_argument("-g", "--goldstandard_file", type=str, required=True)
-    #parser.add_argument("-e", "--entity_type", type=str, required=True)
-    parser.add_argument("-o", "--output", type=str)
+    parser.add_argument("-o", "--output", type=str, default="results.json")
     return parser.parse_args()
 
 def extract_gs_file(folder):
@@ -143,7 +142,7 @@ def main():
     )
 
     # print the results to a JSON file
-    with open("results.json", "w") as out:
+    with open(args.output, "w") as out:
         out.write(res)
     # print the validation status to STDOUT
     print(status)


### PR DESCRIPTION
The validate.py and score.py have been updated to reflect the following changes:

For validate.py 

- [x] Removed the entity_type parameter
- [x] Print the validation status to STDOUT (either “VALIDATED” or “INVALID”)
- [x] Used “validation_status” and “validation_errors” in the output JSON file (instead of “submission_status” and “submission_errors”)
- [x] Added logic to get the groundtruth file from a folder, since ORCA will download the groundtruth file from Synapse into a folder, using [this function](https://github.com/Sage-Bionetworks-Challenges/orca-evaluation-templates/blob/main/utils.py).

The script runs and creates a results.json file and the STDOUT appears as:
```
python validate.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt

VALIDATED
```

Inspection of the results.json from the command line yields the following:
```
cat results.json | python -m json.tool
{
    "validation_status": "VALIDATED",
    "validation_errors": ""
}
```

An error is thrown if the specified goldstandard is not a folder:

```
python validate.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt/Leaderboard_set.csv
Traceback (most recent call last):
  File "/Users/mdiaz/Desktop/current_challenges/olfactory-mixtures-prediction/validate.py", line 151, in <module>
    main()
  File "/Users/mdiaz/Desktop/current_challenges/olfactory-mixtures-prediction/validate.py", line 131, in main
    gold_file=extract_gs_file(args.goldstandard_file), pred_file=args.predictions_file
  File "/Users/mdiaz/Desktop/current_challenges/olfactory-mixtures-prediction/validate.py", line 38, in extract_gs_file
    raise ValueError(
ValueError: Expected exactly one goldstandard file in folder. Got 0. Exiting.
```

For score.py

- [x] Added logic so that the script first checks the validation_status from the output JSON file
- [x] If validation_status is VALIDATED, proceed with the evaluation process.
- [x] If validation_errors is INVALID, skip the evaluation and assign score_errors a descriptive error message, such as Submission could not be evaluated due to validation errors. 
- [x] Added logic to get the groundtruth file from a folder, since ORCA will download the groundtruth file from Synapse into a folder, using [this function](https://github.com/Sage-Bionetworks-Challenges/orca-evaluation-templates/blob/main/utils.py).
- [x] Used “score_status” in the output JSON file (instead of “submission_status”)
- [x] Added “score_errors” to the output JSON file - you can use an empty string if no errors were encountered during validation or scoring
- [x] Print the scoring status to STDOUT (either “SCORED” or “INVALID”)
- [x] Added logic to get the groundtruth file from a folder

Verified that the script still runs and produced this STDOUT:

```
python score.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt
Checking the validation_status.
Scoring the submission.
SCORED.
```

Inspection of the results.json from the command line yields the following:

```
cat results.json | python -m json.tool
{
    "validation_status": "VALIDATED",
    "validation_errors": "",
    "score_status": "SCORED",
    "score_errors": "",
    "RMSE": 0.3423840936469181,
    "Pearson_correlation": -0.007051228097364621
}
```

Invalid submissions will not proceed through scoring:
```
python score.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt
Checking the validation_status.
INVALID
```

The results.json will update to reflect:

cat results.json | python -m json.tool
```
{
    "validation_status": "INVALID",
    "validation_errors": "ERROR",
    "score_status": "INVALID",
    "score_errors": "Submission could not be evaluated due to validation errors."
}
```

@vpchung  Please let me know if you'd like additional exception handling. I have ideas but given the turnaround time for the launch of this challenge I kept things as simple as possible.