### PR TITLE
Bug Fix: Remove All Print Statements that Aren't Status Updates

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -41,9 +41,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      - name: Generate artifact attestation for provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+      # - name: Generate artifact attestation for provenance
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+      #     subject-digest: ${{ steps.push.outputs.digest }}
+      #     push-to-registry: true

--- a/score.py
+++ b/score.py
@@ -59,7 +59,6 @@ def check_validation_status(filename, args):
     
     with open(filename, "r") as f:
         status_result = json.load(f)
-    print("Checking the validation_status.")
     
     if status_result.get("validation_status") == "INVALID":
         new_data = {"validation_status": "INVALID",
@@ -72,8 +71,6 @@ def check_validation_status(filename, args):
 
         print("INVALID")
     else:
-        print("Scoring the submission.")
-        
         pred = pd.read_csv(args.predictions_file)
         gold = pd.read_csv(extract_gs_file(args.goldstandard_folder))
 


### PR DESCRIPTION
This PR addresses an issue raised in PR #1 ![image](https://github.com/user-attachments/assets/046f90f3-470f-40fa-849b-636e6705b6e2)
All print statements that were not status updates have been removed from `score.py`. There were no issues in `validate.py`.
The output now appears as:
```
python score.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt
SCORED
```
Rather than this STDOUT that was previously being produced:

```
python score.py -p /Users/mdiaz/Downloads/predictions.csv -g /Users/mdiaz/Downloads/dream_gt
Checking the validation_status.
Scoring the submission.
SCORED
```

The provenance step of the GitHub workflow failed previously and has been commented out within `.github/workflows/deploy-image.yml` to enable the use of this naming format for new releases/tags: `v1.0.1+2025`