### PR TITLE
Feature: Add CLI Arguments to validate.py and score.py

### DIFF
--- a/score.py
+++ b/score.py
@@ -22,6 +22,7 @@ def get_args():
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
     parser.add_argument("-g", "--goldstandard_folder", type=str, required=True)
     parser.add_argument("-o", "--output", type=str, default="results.json")
+    parser.add_argument("-t", "--task", type=str, default="task1")
     return parser.parse_args()
 
 

--- a/validate.py
+++ b/validate.py
@@ -19,6 +19,7 @@ def get_args():
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
     parser.add_argument("-g", "--goldstandard_folder", type=str, required=True)
     parser.add_argument("-o", "--output", type=str, default="results.json")
+    parser.add_argument("-t", "--task", type=str, default="task1")
     return parser.parse_args()
 
 


### PR DESCRIPTION
The following change has been implemented to allow the distinction between tasks, in the event a challenge uses more than 1 task, within scoring and validation:

- [x] Add a new CLI option to both the validation and scoring scripts called task (shorthand: -t), in anticipation that the challenge will have two tasks (more context here)