### PR TITLE
[fix] Update the pred and gold vectors to stop correlation error

### DIFF
--- a/score.py
+++ b/score.py
@@ -92,7 +92,7 @@ def check_validation_status(filename, args):
             status = "SCORED"
             errors = ""
         except ValueError:
-            status = "NOT SCORED"
+            status = "INVALID"
             errors = "Error encountered during scoring; submission not evaluated."
             scores = {}
         # To be made available once the scoring metrics decided for both tasks

--- a/score.py
+++ b/score.py
@@ -39,7 +39,7 @@ def evaluate_submission(pred, gold):
         pred_vector = pred_df.loc[i, feature_cols].values
         true_vector = gold_df.loc[i, feature_cols].values
 
-        pearson_corr, _ = pearsonr(pred_vector, true_vector)
+        pearson_corr, _ = pearsonr(pred_vector.astype(float), true_vector.astype(float))
         cosine_dist = cosine_distances([pred_vector], [true_vector])[0, 0]
 
         pearson_scores.append(pearson_corr)

--- a/validate.py
+++ b/validate.py
@@ -163,7 +163,7 @@ def main():
     )
 
     # print the results to a JSON file
-    with open(args.output, "w") as out:
+    with open(args.output, "w", encoding="utf-8") as out:
         out.write(res)
     # print the validation status to STDOUT
     print(status)


### PR DESCRIPTION
Issue #10 relates to the identification of a bug in the scoring code where values are not readable when the gold standard and prediction arrays aren't converted to float values as the Pearson correlation is calculated.

Both are now converted to arrays to prevent this issue from occurring.

The results.json now reflects the float values as follows using this [predictions file](https://www.synapse.org/Synapse:syn66312855) and this [groundtruth file](https://www.synapse.org/Synapse:syn65916675):
```
python validate.py -p /Users/mdiaz/Downloads/rubbish_predictions.csv -g /Users/mdiaz/Downloads/bug_test
VALIDATED
```
```
python score.py -p /Users/mdiaz/Downloads/rubbish_predictions.csv -g /Users/mdiaz/Downloads/bug_test
SCORED
```
The results.json appears as:

```
{"validation_status": "VALIDATED", "validation_errors": "", "score_status": "SCORED", "score_errors": "", "pearson_correlation": 0.005963866711740933, "cosine": 0.5269828579457067}
```

Issue #11 calls for the implementation of exception handling to notify participants that scoring has stopped in the event of a scoring error. The check_validation_status function has been updated to include exception handling mimicking that seen in:
* [PEGS ](https://github.com/Sage-Bionetworks-Challenges/orca-evaluation-templates/blob/main/score.py#L170-L181)
* [scoring template](https://github.com/Sage-Bionetworks-Challenges/orca-evaluation-templates/blob/main/score.py#L170-L181)