### PR TITLE
[fix] Update validate.py column names and error message

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -94,7 +94,7 @@ def validate(gold_file, pred_file):
 
     gold = pd.read_csv(gold_file).set_index(INDEX_COL)
     expected_cols = (
-        gold.reset_index().drop(["Intensity", "Pleasantness"], axis=1).dtypes.to_dict()
+        gold.reset_index().dtypes.to_dict()
     )
 
     try:
@@ -108,7 +108,7 @@ def validate(gold_file, pred_file):
         errors.append(
             "Invalid prediction file headers and/or column types. "
             "Expecting `stimulus` (str) and 51 semantic descriptors (float). "
-            "See the Task 1 - Data page for more details."
+            "See the Task page for more details."
         )
     else:
         errors.append(check_dups(pred))


### PR DESCRIPTION
The following changes were made to the validate.py script.

These prediction and goldstandard files were used to test the changes:
Task 1
Submission template: [syn66479970](https://www.synapse.org/Synapse:syn66479970)

Groundtruth: [syn66479969](https://www.synapse.org/Synapse:syn66479969)

Task 2
Submission template: [syn66477943](https://www.synapse.org/Synapse:syn66477943)

Groundtruth: [syn66479976](https://www.synapse.org/Synapse:syn66479976)

The output was as follows on the CLI:
**Task 1**
```
python validate.py -p /Users/mdiaz/Downloads/TASK1_leaderboard_set_Submission_form2.csv -g /Users/mdiaz/Downloads/bug_test1
VALIDATED
```

**Task2**
```
python validate.py -p /Users/mdiaz/Downloads/TASK2_Leaderboard_set_Submission_form2.csv -g /Users/mdiaz/Downloads/bug_test2
VALIDATED
```

The files where there were no predictions, prediction values not between 0 and 5, and so on were deemed `INVALID`.