### PR TITLE
enforce hard cap of 500 char

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -144,12 +144,10 @@ def main():
 
     # truncate validation errors if >500 (character limit for sending email)
     if len(invalid_reasons) > 500:
-        if any(re.search(pattern, line) for line in lines):
-            # If any line contains trigger words, truncate to the first 3 lines
-            invalid_reasons = "\n".join(lines[:3]) + "..."
-        elif any(not re.search(pattern, line) for line in lines):
-            # If any line does not contain trigger words, truncate to 496 characters
-            invalid_reasons = invalid_reasons[:496] + "..."
+        # pick first 3 lines only if any line matches the pattern
+        preview = "\n".join(lines[:3]) if any(pattern.search(l) for l in lines) else invalid_reasons
+        # hard-cap to below 500 chars
+        invalid_reasons = preview[:496] + "..."
 
     # Clean up float-heavy tuples (if present in stringified form)
     invalid_reasons = re.sub(r"\(\s*'([^']+)'(?:,.*?)*\)", r"'\1'", invalid_reasons)


### PR DESCRIPTION
### Problem

I was seeing a [Tower Failure](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/olfactory-challenge-project/watch/MVrYTksSi4aMN) when annotating the submission after validation, saying that the string was >500 characters.

I look at the `results.json` for this submission, and indeed got something larger than 500 characters:

```
>>> len("Found 34 missing stimulus ID(s): ['A298', 'A299', 'A442', 'A468', 'A521', 'A858', 'A867', 'A904', 'A996', 'B015', 'B178', 'B276', 'B374', 'B668', 'B788', 'B878', 'B906', 'C896', 'D082', 'D444', 'D699', 'D819', 'G294', 'G576', 'G595', 'G953', 'H009', 'H521', 'H584', 'H767', 'I425', 'I535', 'I554', 'I986']\nFound 130 unknown stimulus ID(s): ['AA034', 'AA160', 'AA232', 'AA379', 'AA387', 'AA420', 'AA495', 'AA592', 'AB036', 'AB193', 'AB357', 'AB567', 'AB618', 'AB633', 'AB707', 'AB731', 'AB744', 'AC220', 'AC299', 'AC327', 'AC394', 'AC627', 'AC729', 'AC754', 'AC820', 'AC958', 'AD048', 'AD074', 'AD230', 'AD315', 'AD481', 'AD649', 'AD659', 'AD737', 'AD808', 'AE004', 'AE334', 'AE379', 'AE421', 'AE532', 'AE574', 'AE646', 'AE715', 'AE809', 'AE810', 'AE911', 'AE942', 'AE958', 'AG056', 'AG272', 'AG351', 'AG456', 'AG575', 'AH254', 'AH269', 'AH291', 'AH342', 'AH448', 'AH489', 'AH568', 'AH612', 'AH677', 'AH733', 'AH765', 'AI170', 'AI304', 'AI338', 'AI981', 'AJ010', 'AJ266', 'AJ283', 'AJ316', 'AJ481', 'AJ490', 'AJ522', 'AJ537', 'AJ661', 'AK436', 'AK494', 'AK497', 'AK502', 'AK602', 'AK717', 'AK851', 'AK852', 'AK864', 'AK895', 'AK907', 'AK942', 'AK975', 'AL100', 'AL415', 'AL426', 'AL508', 'AL541', 'AL657', 'AL728', 'AL806', 'AL860', 'AL869', 'AM043', 'AM082', 'AM172', 'AM349', 'AM361', 'AM430', 'AM461', 'AM706', 'AM782', 'AM810', 'AM840', 'AM997', 'AN087', 'AN268', 'AN565', 'AN739', 'AN885', 'AO080', 'AO091', 'AO235', 'AO309', 'AO882', 'AP048', 'AP182', 'AP283', 'AP450', 'AP679', 'AP810', 'AP839', 'AP858']...")
1513
>>> 
```

### Solution

The first conditional in the `if` block was not actually enforcing a hard-cap of 500 characters, but rather just adding an elipse at the end.

This logic enforces the 500 character hard-cap, whether or not the trigger words are in the error message.