### PR TITLE
fix syntax

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -145,7 +145,7 @@ def main():
     # truncate validation errors if >500 (character limit for sending email)
     if len(invalid_reasons) > 500:
         # pick first 3 lines only if any line matches the pattern
-        preview = "\n".join(lines[:3]) if any(pattern.search(l) for l in lines) else invalid_reasons
+        preview = "\n".join(lines[:3]) if any(re.search(pattern, l) for l in lines) else invalid_reasons
         # hard-cap to below 500 chars
         invalid_reasons = preview[:496] + "..."
 


### PR DESCRIPTION
### Problem

I accidentally called `.search` on a string rather than the compiled regex.

### Solution

Fix syntax to what it was before

### Testing 

**BEFORE**

```
(synapseclient) w241:olfactory-mixtures-prediction jmedina$ python validate.py -p rubbish_predictions.csv -g gs -o 'results.json'
Traceback (most recent call last):
  File "/Users/jmedina/Documents/forks/olfactory-mixtures-prediction/validate.py", line 171, in <module>
    main()
  File "/Users/jmedina/Documents/forks/olfactory-mixtures-prediction/validate.py", line 148, in main
    preview = "\n".join(lines[:3]) if any(pattern.search(l) for l in lines) else invalid_reasons
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jmedina/Documents/forks/olfactory-mixtures-prediction/validate.py", line 148, in <genexpr>
    preview = "\n".join(lines[:3]) if any(pattern.search(l) for l in lines) else invalid_reasons
                                          ^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'search'

```

**AFTER**

```
(synapseclient) w241:olfactory-mixtures-prediction jmedina$ git checkout patch-1
Switched to branch 'patch-1'
Your branch is up to date with 'origin/patch-1'.
(synapseclient) w241:olfactory-mixtures-prediction jmedina$ python validate.py -p rubbish_predictions.csv -g gs -o 'results.json'
INVALID
```

And for good measure, we ensure that the output validation file is < 500 char:

<img width="405" alt="image" src="https://github.com/user-attachments/assets/2d690db8-482a-453b-9f1b-db65430ccf5e" />

The full validation error is truncated like so:

```
"Found 34 missing stimulus ID(s): ['A298', 'A299', 'A442', 'A468', 'A521', 'A858', 'A867', 'A904', 'A996', 'B015', 'B178', 'B276', 'B374', 'B668', 'B788', 'B878', 'B906', 'C896', 'D082', 'D444', 'D699', 'D819', 'G294', 'G576', 'G595', 'G953', 'H009', 'H521', 'H584', 'H767', 'I425', 'I535', 'I554', 'I986']\nFound 130 unknown stimulus ID(s): ['AA034', 'AA160', 'AA232', 'AA379', 'AA387', 'AA420', 'AA495', 'AA592', 'AB036', 'AB193', 'AB357', 'AB567', 'AB618', 'AB633', 'AB707', 'AB731', 'AB744', 'A..."
```

Is the way we are truncating the IDs a concern, or will participants "get the gist" and know enough to fix the missing IDs?