### PR TITLE
[Fix] Assign lowest rank to ranks that are NaN

### DIFF
--- a/update_ranking.py
+++ b/update_ranking.py
@@ -23,8 +23,8 @@ def rank_submissions(syn, subview_id):
     query = (f"SELECT id, pearson_correlation, cosine, createdOn, submitterid FROM {subview_id} "
              f"WHERE score_status = 'SCORED' ")
     submissions = syn.tableQuery(query).asDataFrame()
-    submissions['pearson_rank'] = submissions['pearson_correlation'].rank(ascending=False, method="min", na_option='top')
-    submissions['cosine_rank'] = submissions['cosine'].rank(ascending=True, method="min", na_option='top')
+    submissions['pearson_rank'] = submissions['pearson_correlation'].rank(ascending=False, method="min", na_option='bottom')
+    submissions['cosine_rank'] = submissions['cosine'].rank(ascending=True, method="min", na_option='bottom')
     submissions['final_rank'] = (submissions['pearson_rank'] + submissions['cosine_rank']) / 2
 
     return submissions


### PR DESCRIPTION
Scored submissions can have an empty current_rank (either because they don’t have a pearson_correlation or cosine score), @gaiaandreoletti advises to give those submissions the lowest ranking.

Pandas `.rank()` offers an [na_option](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rank.html) feature to handle assigning the lowest rank to ranked submissions with a NaN value. It was implemented to correct this issue. 