### PR TITLE
update archive and validate-writeup.cwl for writeup submissions

### DIFF
--- a/writeup-workflow.cwl
+++ b/writeup-workflow.cwl
@@ -1,0 +1,146 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+label: Olfactory mixtures prediction workflow - Writeups
+
+requirements:
+  - class: StepInputExpressionRequirement
+
+inputs:
+  adminUploadSynId:
+    label: Synapse Folder ID accessible by an admin
+    type: string
+  submissionId:
+    label: Submission ID
+    type: int
+  submitterUploadSynId:
+    label: Synapse Folder ID accessible by the submitter
+    type: string
+  synapseConfig:
+    label: filepath to .synapseConfig file
+    type: File
+  workflowSynapseId:
+    label: Synapse File ID that links to the workflow
+    type: string
+  organizers:
+    label: User or team ID for challenge organizers
+    type: string
+    default: "DREAM Olfactory Mixtures Prediction Challenge 2025 Organizers"
+
+outputs: []
+
+steps:
+  01_validate:
+    doc: Check that submission is a valid Synapse project
+    run: writeup-workflow/steps/validate-writeup.cwl
+    in:
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: submissionid
+        source: "#submissionId"
+      - id: challengewiki
+        valueFrom: "syn65660836"
+      - id: public
+        default: true
+      - id: admin
+        source: "#organizers"
+    out:
+      - id: results
+      - id: status
+      - id: invalid_reasons
+  
+  02_validation_email:
+    doc: >
+        Send notifcation email to the submitter whether writeup submission
+        has been accepted
+    run: |-
+        https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/validate_email.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: status
+        source: "#01_validate/status"
+      - id: invalid_reasons
+        source: "#01_validate/invalid_reasons"
+      # - id: errors_only
+      #   default: true
+    out: [finished]
+
+  03_annotate_validation_with_output:
+    doc: >
+      Add `submission_status` and `submission_errors` annotations to the
+      submission
+    run: |-
+      https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#01_validate/results"
+      - id: to_public
+        default: true
+      - id: force
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+    out: [finished]
+
+  04_check_status:
+    run: |-
+      https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/check_status.cwl
+    in:
+      - id: status
+        source: "#01_validate/status"
+      - id: previous_annotation_finished
+        source: "#03_annotate_validation_with_output/finished"
+      - id: previous_email_finished
+        source: "#02_validation_email/finished"
+    out: [finished]
+ 
+  05_archive:
+    doc: Create a copy of the Synapse project for archival purposes
+    run: writeup-workflow/steps/archive.cwl
+    in:
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: submissionid
+        source: "#submissionId"
+      - id: admin
+        source: "#organizers"
+      - id: check_validation_finished 
+        source: "#04_check_status/finished"
+    out:
+      - id: results
+
+  06_annotate_archive_with_output:
+    doc: Add `writeup` annotation to the submission
+    run: |-
+      https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/v4.1/cwl/annotate_submission.cwl
+    in:
+      - id: submissionid
+        source: "#submissionId"
+      - id: annotation_values
+        source: "#05_archive/results"
+      - id: to_public
+        default: true
+      - id: force
+        default: true
+      - id: synapse_config
+        source: "#synapseConfig"
+      - id: previous_annotation_finished
+        source: "#03_annotate_validation_with_output/finished"
+    out: [finished]
+
+s:author:
+- class: s:Person
+  s:identifier: https://orcid.org/0000-0002-5622-7998
+  s:email: verena.chung@sagebase.org
+  s:name: Verena Chung
+
+s:codeRepository: https://github.com/Sage-Bionetworks-Challenges/olfactory-mixtures-prediction
+s:license: https://spdx.org/licenses/Apache-2.0
+
+$namespaces:
+  s: https://schema.org/

--- a/writeup-workflow.cwl
+++ b/writeup-workflow.cwl
@@ -39,7 +39,7 @@ steps:
       - id: submissionid
         source: "#submissionId"
       - id: challengewiki
-        valueFrom: "syn65660836"
+        valueFrom: "syn64743570"
       - id: public
         default: true
       - id: admin

--- a/writeup-workflow.cwl
+++ b/writeup-workflow.cwl
@@ -138,6 +138,10 @@ s:author:
   s:identifier: https://orcid.org/0000-0002-5622-7998
   s:email: verena.chung@sagebase.org
   s:name: Verena Chung
+- class: s:Person
+  s:email: maria.diaz@sagebase.org
+  s:name: Maria Diaz
+
 
 s:codeRepository: https://github.com/Sage-Bionetworks-Challenges/olfactory-mixtures-prediction
 s:license: https://spdx.org/licenses/Apache-2.0

--- a/writeup-workflow/steps/archive.cwl
+++ b/writeup-workflow/steps/archive.cwl
@@ -1,10 +1,7 @@
 #!/usr/bin/env cwl-runner
-#
-# Archive a Project (writeup) submission
-#
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: challengeutils
+label: Archive a Project (writeup) submission
 
 hints:
   DockerRequirement:
@@ -23,6 +20,13 @@ inputs:
   - id: check_validation_finished
     type: boolean?
 
+outputs:
+  - id: results
+    type: File
+    outputBinding:
+      glob: results.json
+
+baseCommand: challengeutils
 arguments:
   - valueFrom: $(inputs.synapse_config.path)
     prefix: -c
@@ -32,8 +36,14 @@ arguments:
   - valueFrom: results.json
     prefix: --output
 
-outputs:
-  - id: results
-    type: File
-    outputBinding:
-      glob: results.json
+s:author:
+- class: s:Person
+  s:identifier: https://orcid.org/0000-0002-5622-7998
+  s:email: verena.chung@sagebase.org
+  s:name: Verena Chung
+
+s:codeRepository: https://github.com/Sage-Bionetworks-Challenges/olfactory-mixtures-prediction
+s:license: https://spdx.org/licenses/Apache-2.0
+
+$namespaces:
+  s: https://schema.org/

--- a/writeup-workflow/steps/validate-writeup.cwl
+++ b/writeup-workflow/steps/validate-writeup.cwl
@@ -1,10 +1,7 @@
 #!/usr/bin/env cwl-runner
-#
-# Validate a Project (writeup) submission
-#
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: challengeutils
+label: Validate a Project (writeup) submission
 
 hints:
   DockerRequirement:
@@ -25,6 +22,25 @@ inputs:
   - id: synapse_config
     type: File
 
+outputs:
+  - id: results
+    type: File
+    outputBinding:
+      glob: results.json
+  - id: status
+    type: string
+    outputBinding:
+      glob: results.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+  - id: invalid_reasons
+    type: string
+    outputBinding:
+      glob: results.json
+      loadContents: true
+      outputEval: $(JSON.parse(self[0].contents)['submission_errors'])
+
+baseCommand: challengeutils
 arguments:
   - valueFrom: $(inputs.synapse_config.path)
     prefix: -c
@@ -38,22 +54,14 @@ arguments:
   - valueFrom: results.json
     prefix: --output
 
-outputs:
-  - id: results
-    type: File
-    outputBinding:
-      glob: results.json
+s:author:
+- class: s:Person
+  s:identifier: https://orcid.org/0000-0002-5622-7998
+  s:email: verena.chung@sagebase.org
+  s:name: Verena Chung
 
-  - id: status
-    type: string
-    outputBinding:
-      glob: results.json
-      loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['submission_status'])
+s:codeRepository: https://github.com/Sage-Bionetworks-Challenges/olfactory-mixtures-prediction
+s:license: https://spdx.org/licenses/Apache-2.0
 
-  - id: invalid_reasons
-    type: string
-    outputBinding:
-      glob: results.json
-      loadContents: true
-      outputEval: $(JSON.parse(self[0].contents)['submission_errors'])
+$namespaces:
+  s: https://schema.org/


### PR DESCRIPTION
The archive and validate-writeup.cwl from [dream-target-2035](https://github.com/Sage-Bionetworks-Challenges/dream-target-2035/blob/main/writeup-workflow.cwl) were added to this workflow.

The writeup-workflow.cwl was added to the repo to call these scripts for writeups.